### PR TITLE
initial cut of cursor support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,8 @@ changes = readfile('CHANGES.rst')
 
 requires = [
     'SQLAlchemy',
+    'transaction',
+    'zope.sqlalchemy',
 ]
 
 tests_require = [

--- a/src/psycopg2_mq/model.py
+++ b/src/psycopg2_mq/model.py
@@ -46,7 +46,7 @@ def make_default_model(metadata, JobStates=JobStates):
         id = Column(BigInteger, primary=True)
         start_time = Column(DateTime)
         end_time = Column(DateTime)
-        state = Column(state_enum, nullable=False)
+        state = Column(state_enum, nullable=False, index=True)
 
         created_time = Column(DateTime, nullable=False)
         scheduled_time = Column(DateTime, nullable=False, index=True)

--- a/src/psycopg2_mq/model.py
+++ b/src/psycopg2_mq/model.py
@@ -1,7 +1,7 @@
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql as pg
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.schema import Column, CheckConstraint
+from sqlalchemy.schema import Column, CheckConstraint, Index
 from sqlalchemy.types import (
     BigInteger,
     DateTime,
@@ -12,9 +12,10 @@ from sqlalchemy.types import (
 
 
 class Model:
-    def __init__(self, Job, JobStates):
+    def __init__(self, Job, JobStates, JobCursor):
         self.Job = Job
         self.JobStates = JobStates
+        self.JobCursor = JobCursor
 
 
 class JobStates:
@@ -42,18 +43,20 @@ def make_default_model(metadata, JobStates=JobStates):
     class Job(Base):
         __table_name__ = 'mq_job'
 
-        id = Column(BigInteger)
+        id = Column(BigInteger, primary=True)
         start_time = Column(DateTime)
         end_time = Column(DateTime)
-        state = Column(state_enum, nullable=False, index=True)
+        state = Column(state_enum, nullable=False)
 
-        created_time = Column(DateTime, nullable=False, index=True)
+        created_time = Column(DateTime, nullable=False)
         scheduled_time = Column(DateTime, nullable=False, index=True)
 
         queue = Column(Text, nullable=False, index=True)
         method = Column(Text, nullable=False)
         args = Column(pg.JSONB, nullable=False)
         result = Column(pg.JSONB)
+
+        cursor_key = Column(Text)
 
         lock_id = Column(Integer, nullable=True, unique=True)
 
@@ -65,6 +68,18 @@ def make_default_model(metadata, JobStates=JobStates):
                 ),
                 name='ck_mq_job_lock_id',
             ),
+            Index(
+                'uq_mq_job_pending_cursor_key',
+                cursor_key,
+                postgresql_where=state == JobStates.PENDING,
+                unique=True,
+            ),
+            Index(
+                'uq_mq_job_running_cursor_key',
+                cursor_key,
+                postgresql_where=state == JobStates.RUNNING,
+                unique=True,
+            ),
         )
 
         def __repr__(self):
@@ -74,8 +89,18 @@ def make_default_model(metadata, JobStates=JobStates):
                 'state="{0.state}", '
                 'scheduled_time={0.scheduled_time}, '
                 'queue="{0.queue}", '
-                'method="{0.method}"'
+                'method="{0.method}", '
+                'cursor_key="{0.cursor_key}"'
                 ')'
             ).format(self)
 
-    return Model(Job, JobStates)
+    class JobCursor(Base):
+        __table_name__ = 'mq_job_cursor'
+
+        key = Column(Text, primary=True)
+        properties = Column(pg.JSONB, default=dict, nullable=False)
+
+        def __repr__(self):
+            return '<JobCursor(key="{0.key}")>'.format(self)
+
+    return Model(Job, JobStates, JobCursor)

--- a/src/psycopg2_mq/source.py
+++ b/src/psycopg2_mq/source.py
@@ -66,6 +66,7 @@ class MQSource:
                 )
                 .on_conflict_do_nothing(
                     index_elements=[Job.cursor_key],
+                    index_where=(Job.state == JobStates.PENDING),
                 )
                 .returning(Job.id)
             )

--- a/src/psycopg2_mq/source.py
+++ b/src/psycopg2_mq/source.py
@@ -16,11 +16,11 @@ class MQSource:
         *,
         dbsession,
         model,
-        tm=None,
+        transaction_manager=None,
     ):
         self.dbsession = dbsession
         self.model = model
-        self.tm = tm
+        self.transaction_manager = transaction_manager
 
     def call(
         self,
@@ -95,7 +95,7 @@ class MQSource:
             epoch_seconds = datetime_to_int(when)
             payload = json.dumps({'j': job_id, 't': epoch_seconds})
             self.dbsession.execute(sa.select([sa.func.pg_notify(queue, payload)]))
-            if self.tm:
+            if self.transaction_manager:
                 mark_changed(self.dbsession)
 
             log.info('enqueuing job=%s on queue=%s, method=%s',

--- a/src/psycopg2_mq/source.py
+++ b/src/psycopg2_mq/source.py
@@ -94,7 +94,9 @@ class MQSource:
         if job_is_new:
             epoch_seconds = datetime_to_int(when)
             payload = json.dumps({'j': job_id, 't': epoch_seconds})
-            self.dbsession.execute(sa.select([sa.func.pg_notify(queue, payload)]))
+            self.dbsession.execute(sa.select([
+                sa.func.pg_notify(queue, payload),
+            ]))
             if self.transaction_manager:
                 mark_changed(self.dbsession)
 

--- a/src/psycopg2_mq/source.py
+++ b/src/psycopg2_mq/source.py
@@ -116,7 +116,6 @@ class MQSource:
     def retry(self, job_id):
         job = self.find_job(job_id)
         if job is None or job.state not in {
-            self.model.JobStates.RUNNING,
             self.model.JobStates.FAILED,
             self.model.JobStates.LOST,
         }:
@@ -124,4 +123,5 @@ class MQSource:
         return self.call(
             job.queue, job.method, job.args,
             when=job.scheduled_time,
+            cursor_key=job.cursor_key,
         )

--- a/src/psycopg2_mq/source.py
+++ b/src/psycopg2_mq/source.py
@@ -1,6 +1,8 @@
 from datetime import datetime
 import json
 import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import insert
+from zope.sqlalchemy import mark_changed
 
 from .util import datetime_to_int
 
@@ -14,47 +16,101 @@ class MQSource:
         *,
         dbsession,
         model,
+        tm=None,
     ):
         self.dbsession = dbsession
         self.model = model
+        self.tm = tm
 
-    def call(self, queue, method, args, when=None, now=None, job_kwargs=None):
-        if job_kwargs is None:
-            job_kwargs = {}
+    def call(
+        self,
+        queue,
+        method,
+        args,
+        *,
+        when=None,
+        now=None,
+        cursor_key=None,
+        job_kwargs=None,
+    ):
         if now is None:
             now = datetime.utcnow()
         if when is None:
             when = now
         if args is None:
             args = {}
-        job = self.model.Job(
-            queue=queue,
-            method=method,
-            args=args,
-            created_time=now,
-            scheduled_time=when,
-            state=self.model.JobStates.PENDING,
-            **job_kwargs,
-        )
-        self.dbsession.add(job)
-        self.dbsession.flush()
+        if job_kwargs is None:
+            job_kwargs = {}
 
-        epoch_seconds = datetime_to_int(job.scheduled_time)
-        payload = json.dumps({'j': job.id, 't': epoch_seconds})
-        self.dbsession.execute(
-            sa.select([sa.func.pg_notify(job.queue, payload)]),
-        )
+        Job = self.model.Job
+        JobStates = self.model.JobStates
 
-        log.info('enqueuing job=%s on queue=%s, method=%s',
-                 job.id, queue, method)
-        return job
+        job_id = None
+        job_is_new = False
+        # there is a race condition here in READ COMMITTED mode where
+        # a job could start between the insert and the query, so if we
+        # do not get a locked job record here we will loop until we either
+        # insert a new row or get a locked one
+        while job_id is None:
+            result = self.dbsession.execute(
+                insert(Job.__table__)
+                .values(
+                    queue=queue,
+                    method=method,
+                    args=args,
+                    created_time=now,
+                    scheduled_time=when,
+                    state=JobStates.PENDING,
+                    cursor_key=cursor_key,
+                    **job_kwargs,
+                )
+                .on_conflict_do_nothing(
+                    index_elements=[Job.cursor_key],
+                )
+                .returning(Job.id)
+            )
+            job_id, = next(result, (None,))
+
+            # we just inserted a new job, notify workers
+            if job_id is not None:
+                job_is_new = True
+                break
+
+            # a job already exists, so let's find it and return the id
+            # we lock the job in the pending state to ensure that it doesn't
+            # start until our transaction completes with data that should be
+            # used in the worker
+            job_id = (
+                self.dbsession.query(Job.id)
+                .with_for_update()
+                .filter(
+                    Job.state == JobStates.PENDING,
+                    Job.cursor_key == cursor_key,
+                )
+                .scalar()
+            )
+
+        if job_is_new:
+            epoch_seconds = datetime_to_int(when)
+            payload = json.dumps({'j': job_id, 't': epoch_seconds})
+            self.dbsession.execute(sa.select([sa.func.pg_notify(queue, payload)]))
+            if self.tm:
+                mark_changed(self.dbsession)
+
+            log.info('enqueuing job=%s on queue=%s, method=%s',
+                     job_id, queue, method)
+
+        else:
+            log.debug('joining existing job=%s', job_id)
+
+        return job_id
 
     @property
     def query(self):
         return self.dbsession.query(self.model.Job)
 
-    def find_job(self, id):
-        return self.query.get(id)
+    def find_job(self, job_id):
+        return self.query.get(job_id)
 
     def retry(self, job_id):
         job = self.find_job(job_id)

--- a/src/psycopg2_mq/worker.py
+++ b/src/psycopg2_mq/worker.py
@@ -272,6 +272,7 @@ def finish_job(ctx, job_id, success, result, cursor=None):
                     key=job.cursor_key,
                     properties=cursor,
                 )
+                db.add(cursor_obj)
 
             elif cursor_obj.properties != cursor:
                 cursor_obj.properties = cursor or {}


### PR DESCRIPTION
Basically start using `source.call(..., cursor_key=...)`. This defines a unique cursor (in the future we might try to auto-generate the key based on queue/method/args). There can only be one pending job and one running job using the same cursor. The running job is passed a `job.cursor` dict, which will be saved to the database when successfully completed or discarded on failure.