### PR TITLE
define a schedule model which can emit new jobs using recurrence rules

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+unreleased
+==========
+
+- Add a scheduler model with support for emitting periodic jobs based on
+  RRULE syntax.
+  See https://github.com/mmerickel/psycopg2_mq/pull/11
+
 0.4.5 (2020-12-22)
 ==================
 

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ readme = readfile('README.rst')
 changes = readfile('CHANGES.rst')
 
 requires = [
+    'python-dateutil',
     'SQLAlchemy',
     'transaction',
     'zope.sqlalchemy',

--- a/src/psycopg2_mq/source.py
+++ b/src/psycopg2_mq/source.py
@@ -216,6 +216,7 @@ class MQSource:
             log.info(f'schedule={schedule_id} is already disabled')
             return
         schedule.is_enabled = False
+        schedule.next_execution_time = None
         log.debug(f'disabled schedule={schedule_id}')
 
     def enable_schedule(self, schedule_id, *, now=None, reload=True):

--- a/src/psycopg2_mq/source.py
+++ b/src/psycopg2_mq/source.py
@@ -212,14 +212,14 @@ class MQSource:
         schedule.is_enabled = False
         log.debug(f'disabled schedule={schedule_id}')
 
-    def enable_schedule(self, schedule_id, *, now=None):
+    def enable_schedule(self, schedule_id, *, now=None, reload=True):
         if now is None:
             now = datetime.utcnow()
         schedule = self.find_schedule(schedule_id)
         schedule.is_enabled = True
         schedule.next_execution_time = get_next_schedule_execution_time(
             schedule.rrule, schedule.created_time, now)
-        if schedule.next_execution_time is not None:
+        if reload and schedule.next_execution_time is not None:
             self.reload_schedule_queue(schedule.queue, now=schedule.next_execution_time)
         log.debug(
             f'enabling schedule={schedule_id}, '


### PR DESCRIPTION
- Jobs are scheduled at their expected start times.
- If a job is running when it's time for a new job, a new one is scheduled concurrently.
- If the scheduler is not running when a job is set to start, all scheduling intervals are skipped, and one job is created when the scheduler starts up.
- To avoid this, use cursors with the schedule.
- Recurrence rules are used for flexible schedules using calendar-based or period-based logic.
- The source object is used to add/update schedules and can trigger the workers to reload their state.
- Auto-scheduling can be turned off to control explicitly which worker is handling scheduling.
- Care must be taken to only have one worker daemon scheduling jobs for a specific queue until cluster support is added.